### PR TITLE
Allow configuring html_dir via the command line and fix run_example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ __pycache__/
 # Sphinx documentation
 docs/_build/
 
+# Build files
+venv/
+
 # Temporary files
 _.*
+/output/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+default: example
+
+example:
+	./venv/bin/python3 run_example.py -d .

--- a/ddhf/ddhf/decorated_context.py
+++ b/ddhf/ddhf/decorated_context.py
@@ -110,12 +110,28 @@ OK_ENVS = {
     "AUTOARCHAEOLOGIST_BITSTORE_CACHE": "ddhf_bitstore_cache",
 }
 
-def main(job, html_subdir="tmp", **kwargs):
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--out', default='/tmp/_autoarchaologist')
+
+    args = parser.parse_args(args=argv)
+    if args.out == '.':
+        args.out = os.path.join(os.getcwd(), "_autoarchaologist")
+    return args
+
+def main(job, html_subdir, **kwargs):
+    args = parse_arguments()
+    kwargs["html_dir"] = args.out
+
     ''' A standard main routine to reduce boiler-plate '''
     for key in os.environ:
         i = OK_ENVS.get(key)
         if i:
             kwargs[i] = os.environ[key]
+
+    if 'html_dir' not in kwargs:
+        raise AttributeError("missing: html_dir")
+
 
     kwargs['html_dir'] = os.path.join(kwargs['html_dir'], html_subdir)
     kwargs.setdefault('download_links', True)

--- a/run_example.py
+++ b/run_example.py
@@ -1,19 +1,35 @@
 
+import argparse
 import os
+import sys
 
 import autoarchaeologist
 
-from autoarchaeologist.generic.bigdigits import BigDigits
+from autoarchaeologist.generic.bigtext import BigText
 from autoarchaeologist.generic.samesame import SameSame
 from autoarchaeologist.data_general.absbin import AbsBin
 from autoarchaeologist.data_general.papertapechecksum import DGC_PaperTapeCheckSum
 
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dir", default="/tmp/_autoarchaologist")
+
+    args = parser.parse_args(args=argv)
+    if args.dir == ".":
+        args.dir = os.path.join(os.getcwd(), "output", "_autoarchaologist")
+    return args
 
 if __name__ == "__main__":
+    args = parse_arguments()
 
-    ctx = autoarchaeologist.Excavation()
+    try:
+        os.mkdir(args.dir)
+    except FileExistsError:
+        pass
 
-    ctx.add_examiner(BigDigits)
+    ctx = autoarchaeologist.Excavation(html_dir=args.dir)
+
+    ctx.add_examiner(BigText)
     ctx.add_examiner(AbsBin)
     ctx.add_examiner(DGC_PaperTapeCheckSum)
     ctx.add_examiner(SameSame)
@@ -22,11 +38,6 @@ if __name__ == "__main__":
 
     ctx.start_examination()
 
-    try:
-        os.mkdir("/tmp/_autoarchaologist")
-    except FileExistsError:
-        pass
-
-    ctx.produce_html(html_dir="/tmp/_autoarchaologist")
+    ctx.produce_html()
 
     print("Now point your browser at", ctx.filename_for(ctx).link)


### PR DESCRIPTION
Support a directory argument of "." to allow outputting in the current directory with an automatic suffix: ./_autoarchaologist

While here also remove broken reference to a metadata internals class that appears unused and prevents run_example from functioning.