### PR TITLE
Unified run.py file allowing execution of an excavator against a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/_build/
 # Temporary files
 _.*
 _autoarchaologist/
+tests/_scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/_build/
 
 # Temporary files
 _.*
+_autoarchaologist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	@python3 -m unittest discover
+	@python3 -m unittest discover tests/autoarchaologist
+
+default: test

--- a/README.md
+++ b/README.md
@@ -8,6 +8,35 @@ computers, in a convenient and user-friendly way.
 The AutoArchaeologist is a framework where plugins can be written to take
 apart and present old data media, in a browser-friendly fashion.
 
+## Getting started
+
+To get a feel for how this works and ensure you've got everything set up,
+we've included a sample file that can be excavated as an example:
+
+```sh
+python3 run_example.py
+```
+
+When you're ready to for further and process you own images use `run.py`.
+
+## Using run.py
+
+The various utilities that allow the extraction and processing of data are
+designed to be composed into an Excavation that can be run against binary
+images of disks and other media. Some standard excavations have been put
+together in bundles ad exposed via a single `run` command.
+
+Performing an exavation of a file is as simple as the following:
+
+```sh
+python3 run.py --excavator <excavator> <filename>
+```
+
+Usage information including the list of excavatos that are avalable as well as
+other options will be output when running without arguments: `python3 run.py`.
+
+## From the DDHF
+
 # First Example: Commodore CBM900 Harddisk
 
 Our first historic use of the AutoArchaeologist is now online:

--- a/autoarchaeologist/__init__.py
+++ b/autoarchaeologist/__init__.py
@@ -4,3 +4,4 @@ import os
 from .base.excavation import Excavation, DuplicateArtifact
 from .record import Record
 from .base.namespace import NameSpace
+from . import excavators

--- a/autoarchaeologist/base/excavation.py
+++ b/autoarchaeologist/base/excavation.py
@@ -389,7 +389,7 @@ class Excavation():
             font-family: "Inconsolata", "Courier New", mono-space;
         }
         td,th {
-            padding: 0 10px 0; 
+            padding: 0 10px 0;
         }
         th {
             position: sticky; top: 0; background-color: #eeeeee;

--- a/autoarchaeologist/ddhf/bitstore.py
+++ b/autoarchaeologist/ddhf/bitstore.py
@@ -8,8 +8,6 @@ import os
 import mmap
 import urllib.request
 
-import ddhf_bitstore_metadata
-
 from ..base import artifact
 from ..base import excavation
 from ..container import simh_tap_file
@@ -163,10 +161,6 @@ class FromBitStore():
         metatxt = self.fetch_meta(arg)
         if metatxt is None:
             print("Could not fetch", arg)
-            return
-
-        meta = ddhf_bitstore_metadata.internals.metadata.MetadataBase(metatxt)
-        if meta is None:
             return
 
         if self.media_types and not self.check_media_type(meta):

--- a/autoarchaeologist/ddhf/cpm_excavator.py
+++ b/autoarchaeologist/ddhf/cpm_excavator.py
@@ -4,6 +4,7 @@
 '''
 
 
+from ..base import excavation
 from ..base import type_case
 from ..generic import samesame
 from ..generic import textfiles
@@ -12,10 +13,12 @@ from ..DigitalResearch import cpm
 cpm.cpm_filename_typecase.set_slug(0x5f, '_', '_')
 cpm.cpm_filename_typecase.set_slug(0x3b, ';', ';')
 
-def std_cpm_excavation(exc):
+class Cpm(excavation.Excavation):
+
     ''' Standard CP/M excavation '''
 
-    exc.type_case = type_case.DS2089Cpm()
-    exc.add_examiner(cpm.CpmFileSystem)
-    exc.add_examiner(textfiles.TextFile)
-    exc.add_examiner(samesame.SameSame)
+    def __init__(self, **kwargs):
+        self.type_case = type_case.DS2089Cpm()
+        self.add_examiner(cpm.CpmFileSystem)
+        self.add_examiner(textfiles.TextFile)
+        self.add_examiner(samesame.SameSame)

--- a/autoarchaeologist/ddhf/decorated_context.py
+++ b/autoarchaeologist/ddhf/decorated_context.py
@@ -6,6 +6,7 @@
 
 '''
 
+import argparse
 import os
 
 from ..base import excavation
@@ -84,12 +85,28 @@ OK_ENVS = {
     "AUTOARCHAEOLOGIST_BITSTORE_CACHE": "ddhf_bitstore_cache",
 }
 
-def main(job, html_subdir="tmp", **kwargs):
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--out', default='/tmp/_autoarchaologist')
+
+    args = parser.parse_args(args=argv)
+    if args.out == '.':
+        args.out = os.path.join(os.getcwd(), "_autoarchaologist")
+    return args
+
+def main(job, html_subdir, **kwargs):
+    args = parse_arguments()
+    kwargs["html_dir"] = args.out
+
     ''' A standard main routine to reduce boiler-plate '''
     for key in os.environ:
         i = OK_ENVS.get(key)
         if i:
             kwargs[i] = os.environ[key]
+
+    if 'html_dir' not in kwargs:
+        raise AttributeError("missing: html_dir")
+
 
     kwargs['html_dir'] = os.path.join(kwargs['html_dir'], html_subdir)
     kwargs.setdefault('download_links', True)

--- a/autoarchaeologist/ddhf/decorated_context.py
+++ b/autoarchaeologist/ddhf/decorated_context.py
@@ -19,6 +19,7 @@ class DDHF_Excavation(excavation.Excavation):
 
     def __init__(
         self,
+        Excavation,
         ddhf_topic=None,
         ddhf_topic_link=None,
         ddhf_bitstore_cache=None,
@@ -30,6 +31,9 @@ class DDHF_Excavation(excavation.Excavation):
             ddhf_bitstore_cache = "/tmp/_bitstore_cache"
         self.ddhf_bitstore_cache = ddhf_bitstore_cache
         super().__init__(**kwargs)
+
+        # apply the configuration of the chosen excavation
+        Excavation.__init__(self, **kwargs)
 
     def html_prefix_banner(self, file, _this):
         ''' Emit the banner for this excavation '''

--- a/autoarchaeologist/excavators.py
+++ b/autoarchaeologist/excavators.py
@@ -1,0 +1,55 @@
+import importlib.util
+import os
+import sys
+
+# XXX: importing excavations this way is a kludge to avoid multiple rounds
+#      of file splitting churn that would pollute diffs.. important as the
+#      the most critical thing (for now) is avoiding changes to behaviour
+def _import_name(import_name):
+    import_path = f"{import_name}.py"
+    spec = importlib.util.spec_from_file_location(import_name, import_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+from .ddhf.cpm_excavator import Cpm as cpm
+cbm900 = _import_name("ddhf_cbm900").Cbm900
+cr80 = _import_name("ddhf_cr80").Cr80Floppy
+cr80_wang = _import_name("ddhf_cr80_wang").Cr80Wang
+dask = _import_name("ddhf_dask").Dask
+gier = _import_name("ddhf_gier").Gier
+intel_isis = _import_name("ddhf_intel_isis").IntelISIS
+r1k = _import_name("ddhf_r1k_tapes").R1k
+r1k_backup = _import_name("ddhf_r1k_backup").R1kBackup
+r1k_dfs = _import_name("ddhf_r1k_dfs").R1kDFS
+rc3600 = _import_name("ddhf_rc3600").Rc3600
+uug = _import_name("ddhf_dkuug").DkuugEuug
+zilog_mcz = _import_name("ddhf_zilog_mcz").ZilogMCZ
+
+# from .gier import configure_excavation as gier
+# from .intel_isis import configure_excavation as intel_isis
+# from .r1kdfs import configure_excavation as r1kdfs
+# from .uug import configure_excavation as uug
+
+__all__ = [
+    "cbm900",
+    "cpm",
+    "cr80",
+    "cr80_wang",
+    "dask",
+    "gier",
+    "intel_isis",
+    "r1k",
+    "r1k_backup",
+    "r1k_dfs",
+    "rc3600",
+    "uug",
+    "zilog_mcz",
+]
+
+EXCAVATORS = {name:getattr(sys.modules[__name__], name) for name in __all__}
+
+def excavator_by_name(excavator_name):
+    if excavator_name not in EXCAVATORS:
+        raise LookupError(f'no extractor named "{excavator_name}"')
+    return EXCAVATORS[excavator_name]

--- a/ddhf_butler.py
+++ b/ddhf_butler.py
@@ -3,16 +3,14 @@
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 
-from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist import ddhf, Excavation
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Butler(ddhf.DDHF_Excavation):
+class DDHF_Butler(ddhf.DDHF_Excavation):
     ''' All Butler artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "COMPANY/BOGIKA",
@@ -20,7 +18,7 @@ class Butler(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Butler,
+        DDHF_Butler,
         html_subdir="butler",
         ddhf_topic = 'Bogika Butler',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/BDS_Butler'

--- a/ddhf_cbm900.py
+++ b/ddhf_cbm900.py
@@ -4,6 +4,7 @@ Commodore CBM-900 Artifacts from Datamuseum.dk's BitStore
 '''
 
 from autoarchaeologist import ddhf
+from autoarchaeologist.base import excavation
 
 from autoarchaeologist.unix import cbm900_partition
 from autoarchaeologist.unix import v7_filesystem
@@ -12,7 +13,7 @@ from autoarchaeologist.unix import cbm900_l_out
 from autoarchaeologist.generic import textfiles
 from autoarchaeologist.generic import samesame
 
-class CBM900(ddhf.DDHF_Excavation):
+class Cbm900(excavation.Excavation):
 
     '''
     Two CBM900 hard-disk images, one also contains the four distribution
@@ -29,6 +30,10 @@ class CBM900(ddhf.DDHF_Excavation):
         self.add_examiner(textfiles.TextFile)
         self.add_examiner(samesame.SameSame)
 
+class DDHF_Cbm900(ddhf.DDHF_Excavation):
+    def __init__(self, **kwargs):
+        super().__init__(Cbm900, **kwargs)
+
         self.from_bitstore(
             "30001199",
             "30001972",
@@ -36,7 +41,7 @@ class CBM900(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        CBM900,
+        DDHF_Cbm900,
         html_subdir="cbm900",
         ddhf_topic = "Commodore CBM-900",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Commodore/CBM900',

--- a/ddhf_comet.py
+++ b/ddhf_comet.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Comet(ddhf.DDHF_Excavation):
+class DDHF_Comet(ddhf.DDHF_Excavation):
 
     ''' All Comet artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "COMPANY/ICL/COMET",
@@ -21,7 +19,7 @@ class Comet(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Comet,
+        DDHF_Comet,
         html_subdir="comet",
         ddhf_topic = 'ICL Comet',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/ICL_Comet'

--- a/ddhf_cpm.py
+++ b/ddhf_cpm.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
 class Cpm(ddhf.DDHF_Excavation):
 
     ''' All Cpm artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "-30002875", # PASCAL

--- a/ddhf_cr80.py
+++ b/ddhf_cr80.py
@@ -5,13 +5,14 @@ Christian Rovsing A/S CR80 Artifacts from Datamuseum.dk's BitStore
 
 from autoarchaeologist import ddhf
 
+from autoarchaeologist.base import excavation
 from autoarchaeologist.christianrovsing import cr80_sysone
 from autoarchaeologist.christianrovsing import cr80_fs2
 from autoarchaeologist.intel import isis
 from autoarchaeologist.generic import textfiles
 from autoarchaeologist.zilog import mcz
 
-class Cr80Floppy(ddhf.DDHF_Excavation):
+class Cr80Floppy(excavation.Excavation):
     ''' CR80 Floppy disk images'''
 
     def __init__(self, **kwargs):
@@ -25,13 +26,21 @@ class Cr80Floppy(ddhf.DDHF_Excavation):
         self.add_examiner(mcz.MCZRIO)
         self.add_examiner(textfiles.TextFile)
 
+
+class DDHF_Cr80Floppy(ddhf.DDHF_Excavation):
+
+    ''' CR80 Floppy disk images'''
+
+    def __init__(self, **kwargs):
+        super().__init__(Cr80Floppy, **kwargs)
+
         self.from_bitstore(
             "CR/CR80/SW",
         )
 
 if __name__ == "__main__":
     ddhf.main(
-        Cr80Floppy,
+        DDHF_Cr80Floppy,
         html_subdir="cr80",
         ddhf_topic = "CR80 Hard and Floppy Disks",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/CR80',

--- a/ddhf_cr80_wang.py
+++ b/ddhf_cr80_wang.py
@@ -5,11 +5,12 @@
 
 from autoarchaeologist import ddhf
 
+from autoarchaeologist.base import excavation
 from autoarchaeologist.generic import samesame
 from autoarchaeologist.Wang import wang_wps
 from autoarchaeologist.Wang import wang_text
 
-class Wang(ddhf.DDHF_Excavation):
+class Cr80Wang(excavation.Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -18,13 +19,17 @@ class Wang(ddhf.DDHF_Excavation):
         self.add_examiner(wang_text.WangText)
         self.add_examiner(samesame.SameSame)
 
+class DDHF_Cr80Wang(ddhf.DDHF_Excavation):
+    def __init__(self, **kwargs):
+        super().__init__(Wang, **kwargs)
+
         self.from_bitstore(
             "CR/CR80/DOCS",
         )
 
 if __name__ == "__main__":
     ddhf.main(
-        Wang,
+        DDHF_Cr80Wang,
         html_subdir="cr80_wang",
         ddhf_topic = "CR80 Wang WCS documentation floppies",
         ddhf_topic_link = 'https://datamuseum.dk/wiki',

--- a/ddhf_cr_cpm.py
+++ b/ddhf_cr_cpm.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class CrCpm(ddhf.DDHF_Excavation):
+class DDHF_CrCpm(ddhf.DDHF_Excavation):
 
     ''' All CR8 artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "CR/CR7",
@@ -23,7 +21,7 @@ class CrCpm(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        CrCpm,
+        DDHF_CrCpm,
         html_subdir="cr_cpm",
         ddhf_topic = 'Christian Rovsing CR7, CR8 & CR16 CP/M',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Christian_Rovsing_A/S'

--- a/ddhf_dask.py
+++ b/ddhf_dask.py
@@ -8,6 +8,7 @@ from autoarchaeologist import ddhf
 from autoarchaeologist.regnecentralen import gier_text
 from autoarchaeologist.generic import samesame
 from autoarchaeologist.generic import textfiles
+from autoarchaeologist.base import excavation
 from autoarchaeologist.base import type_case
 
 class DaskTegn(textfiles.TextFile):
@@ -35,12 +36,10 @@ class DaskTc(type_case.TypeCase):
         self.set_slug(0x10, "*", "*")
         self.set_slug(0x1e, " ", "«stop»")
 
-class DASK(ddhf.DDHF_Excavation):
-
-    ''' All DASK artifacts '''
+class Dask(excavation.Excavation):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(Dask, **kwargs)
 
         self.type_case = DaskTc()
 
@@ -48,13 +47,20 @@ class DASK(ddhf.DDHF_Excavation):
         self.add_examiner(samesame.SameSame)
         self.add_examiner(DaskTegn)
 
+class DDHF_DASK(ddhf.DDHF_Excavation):
+
+    ''' All DASK artifacts '''
+
+    def __init__(self, **kwargs):
+        super().__init__(Dask, **kwargs)
+
         self.from_bitstore(
             "DASK/SW",
         )
 
 if __name__ == "__main__":
     ddhf.main(
-        DASK,
+        DDHF_DASK,
         html_subdir="dask",
         ddhf_topic = "RegneCentralen DASK Computer",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/DASK',

--- a/ddhf_dkuug.py
+++ b/ddhf_dkuug.py
@@ -5,16 +5,13 @@ DKUUG and EUUG Conference tapes
 
 from autoarchaeologist import ddhf
 
+from autoarchaeologist.base import excavation
 from autoarchaeologist.generic import textfiles
 from autoarchaeologist.generic import samesame
 from autoarchaeologist.unix import tar_file
 from autoarchaeologist.unix import compress
 
-class DkuugEuug(ddhf.DDHF_Excavation):
-
-    '''
-    DKUUG and EUUG Conference tapes
-    '''
+class DkuugEuug(excavation.Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -23,6 +20,15 @@ class DkuugEuug(ddhf.DDHF_Excavation):
         self.add_examiner(tar_file.TarFile)
         self.add_examiner(textfiles.TextFile)
         self.add_examiner(samesame.SameSame)
+
+class DDHF_DkuugEuug(ddhf.DDHF_Excavation):
+
+    '''
+    DKUUG and EUUG Conference tapes
+    '''
+
+    def __init__(self, **kwargs):
+        super().__init__(DkuugEuug, **kwargs)
 
         self.from_bitstore(
             "30001252",

--- a/ddhf_gier.py
+++ b/ddhf_gier.py
@@ -7,16 +7,21 @@ from autoarchaeologist import ddhf
 
 from autoarchaeologist.regnecentralen import gier_text
 from autoarchaeologist.generic import samesame
+from autoarchaeologist.base import excavation
 
-class GIER(ddhf.DDHF_Excavation):
-
-    ''' All GIER artifacts '''
+class Gier(excavation.Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         self.add_examiner(gier_text.GIER_Text)
         self.add_examiner(samesame.SameSame)
+
+class DDHF_GIER(ddhf.DDHF_Excavation):
+    ''' All GIER artifacts '''
+
+    def __init__(self, **kwargs):
+        super().__init__(Gier, **kwargs)
 
         self.from_bitstore(
             "GIER/ALGOL_4",

--- a/ddhf_intel_isis.py
+++ b/ddhf_intel_isis.py
@@ -7,8 +7,9 @@ from autoarchaeologist import ddhf
 
 from autoarchaeologist.intel import isis
 from autoarchaeologist.generic import textfiles
+from autoarchaeologist.base import excavation
 
-class IntelISIS(ddhf.DDHF_Excavation):
+class IntelISIS(excavation.Excavation):
     ''' Intel ISIS Floppy Disks '''
 
     def __init__(self, **kwargs):
@@ -16,6 +17,12 @@ class IntelISIS(ddhf.DDHF_Excavation):
 
         self.add_examiner(isis.IntelIsis)
         self.add_examiner(textfiles.TextFile)
+
+class DDHF_IntelISIS(ddhf.DDHF_Excavation):
+    ''' Intel ISIS Floppy Disks '''
+
+    def __init__(self, **kwargs):
+        super().__init__(IntelISIS, **kwargs)
 
         self.from_bitstore(
             "COMPANY/INTEL/ISIS",

--- a/ddhf_jet80.py
+++ b/ddhf_jet80.py
@@ -4,16 +4,14 @@ Jet Computer Jet80 Artifacts from Datamuseum.dk's BitStore
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Jet80(ddhf.DDHF_Excavation):
+class DDHF_Jet80(ddhf.DDHF_Excavation):
 
     ''' All Jet80 artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "JET80",
@@ -21,7 +19,7 @@ class Jet80(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Jet80,
+        DDHF_Jet80,
         html_subdir="jet80",
         ddhf_topic = 'Jet Computer Jet80',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Jet_Computer_JET-80'

--- a/ddhf_r1k_backup.py
+++ b/ddhf_r1k_backup.py
@@ -3,7 +3,7 @@
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 
-from autoarchaeologist.ddhf.decorated_context import DDHF_Excavation, main
+from autoarchaeologist import ddhf
 
 from autoarchaeologist.generic import ansi_tape_labels
 from autoarchaeologist.rational.r1k_backup import R1kBackup
@@ -11,6 +11,7 @@ from autoarchaeologist.rational.r1k_e3_objects import R1kE3Objects
 from autoarchaeologist.rational.r1k_assy import R1kAssyFile
 from autoarchaeologist.rational.r1k_6zero import R1k6ZeroSegment
 from autoarchaeologist.rational.r1k_seg_heap import R1kSegHeap
+from autoarchaeologist.base import excavation
 from autoarchaeologist.base import type_case
 from autoarchaeologist.generic import textfiles
 from autoarchaeologist.generic.samesame import SameSame
@@ -36,9 +37,7 @@ class TypeCase(type_case.Ascii):
         super().__init__()
         self.set_slug(0, ' ', '«nul»', self.EOF)
 
-class R1KBACKUP(DDHF_Excavation):
-
-    ''' Rational R1000/400 Backup tape '''
+class R1kBackup(excavation.Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,13 +56,20 @@ class R1KBACKUP(DDHF_Excavation):
         self.add_examiner(TextFile)
         self.add_examiner(SameSame)
 
+class DDHF_R1KBACKUP(ddhf.DDHF_Excavation):
+
+    ''' Rational R1000/400 Backup tape '''
+
+    def __init__(self, **kwargs):
+        super().__init__(R1kBackup, **kwargs)
+
         self.from_bitstore(
             "30000544",	# PAM arrival backup
         )
 
 if __name__ == "__main__":
-    main(
-        R1KBACKUP,
+    ddhf.main(
+        R1kBackup,
         html_subdir="r1k_backup",
         ddhf_topic = "Rational R1000/400",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Rational/R1000s400',

--- a/ddhf_r1k_dfs.py
+++ b/ddhf_r1k_dfs.py
@@ -36,8 +36,7 @@ class TypeCase(type_case.Ascii):
         super().__init__()
         self.set_slug(0, ' ', '«nul»', self.EOF)
 
-class R1KDFS(ddhf.DDHF_Excavation):
-    ''' Rational R1000/400 DFS tapes '''
+class R1kDFS(ddhf.DDHF_Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -54,6 +53,13 @@ class R1KDFS(ddhf.DDHF_Excavation):
 
         self.type_case = TypeCase()
 
+class DDHF_R1KDFS(ddhf.DDHF_Excavation):
+
+    ''' Rational R1000/400 DFS tapes '''
+
+    def __init__(self, **kwargs):
+        super().__init__(R1kDFS, **kwargs)
+
         self.from_bitstore(
             "30000744",   # precise file sizes
             "30000407",   # precise file sizes
@@ -65,7 +71,7 @@ class R1KDFS(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        R1KDFS,
+        DDHF_R1KDFS,
         html_subdir="r1k_dfs",
         ddhf_topic = "Rational R1000/400 DFS Tapes",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Rational/R1000s400',

--- a/ddhf_r1k_diproc.py
+++ b/ddhf_r1k_diproc.py
@@ -5,13 +5,21 @@ Rational R1000/400 Diag Processor Firmware from Datamuseum.dk's BitStore
 from autoarchaeologist import ddhf
 
 from autoarchaeologist.rational import r1k_diag
+from autoarchaeologist.base import excavation
 
-class R1KDIPROC(ddhf.DDHF_Excavation):
+class R1kDiag(excavation.Excavation):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add_examiner(r1k_diag.R1kDiagFirmWare)
+
+class DDHF_R1KDIPROC(ddhf.DDHF_Excavation):
 
     ''' Rational R1000/400 Diag Processor firmware '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(R1kDiag, **kwargs)
 
         self.add_examiner(r1k_diag.R1kDiagFirmWare)
 
@@ -22,7 +30,7 @@ class R1KDIPROC(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        R1KDIPROC,
+        DDHF_R1KDIPROC,
         html_subdir="r1k_diproc",
         ddhf_topic = "Rational R1000/400 Diag Processor Firmware",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/Rational/R1000s400',

--- a/ddhf_r1k_tapes.py
+++ b/ddhf_r1k_tapes.py
@@ -3,7 +3,7 @@ Rational R1000/400 Tapes from Datamuseum.dk's BitStore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 
-from autoarchaeologist.ddhf.decorated_context import DDHF_Excavation, main
+from autoarchaeologist import ddhf
 
 from autoarchaeologist.generic.ansi_tape_labels import AnsiTapeLabels
 from autoarchaeologist.rational import r1k_archive
@@ -12,12 +12,10 @@ from autoarchaeologist.generic.samesame import SameSame
 from autoarchaeologist.unix.compress import Compress
 from autoarchaeologist.unix.tar_file import TarFile
 from autoarchaeologist.generic import textfiles
+from autoarchaeologist.base import excavation
 
-class R1K(DDHF_Excavation):
+class R1k(excavation.Excavation):
 
-    '''
-    Rational R1000/400 tapes except DFS and backup tapes
-    '''
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -29,6 +27,16 @@ class R1K(DDHF_Excavation):
         self.add_examiner(TarFile)
         self.add_examiner(textfiles.TextFile)
         self.add_examiner(SameSame)
+
+
+class R1K(ddhf.DDHF_Excavation):
+
+    '''
+    Rational R1000/400 tapes except DFS and backup tapes
+    '''
+
+    def __init__(self, **kwargs):
+        super().__init__(R1k, **kwargs)
 
         self.from_bitstore(
             "-30000530",	# == 30000409
@@ -49,7 +57,7 @@ class R1K(DDHF_Excavation):
         )
 
 if __name__ == "__main__":
-    main(
+    ddhf.main(
         R1K,
         html_subdir="r1k_tapes",
         ddhf_topic = "Rational R1000/400 Tapes",

--- a/ddhf_rc3600.py
+++ b/ddhf_rc3600.py
@@ -5,6 +5,7 @@
 
 from autoarchaeologist import ddhf
 
+from autoarchaeologist.base import excavation
 from autoarchaeologist.base import type_case
 
 from autoarchaeologist.regnecentralen import domus_fs
@@ -51,9 +52,7 @@ class TextFileOdd(textfiles.TextFile):
     TYPE_CASE = type_case.OddPar(DomusDS2089())
     MAX_TAIL=512*6
 
-class Rc3600(ddhf.DDHF_Excavation):
-
-    ''' All RC3600 artifacts '''
+class Rc3600(excavation.Excavation):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -74,6 +73,13 @@ class Rc3600(ddhf.DDHF_Excavation):
         self.add_examiner(TextFileOdd)
         self.add_examiner(samesame.SameSame)
 
+class DDHF_Rc3600(ddhf.DDHF_Excavation):
+
+    ''' All RC3600 artifacts '''
+
+    def __init__(self, **kwargs):
+        super().__init__(Rc3600, **kwargs)
+
         self.from_bitstore(
             "-30001762",		# Defective
             "RC/RC3600/DOMUS",
@@ -85,7 +91,7 @@ class Rc3600(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Rc3600,
+        DDHF_Rc3600,
         html_subdir="rc3600",
         ddhf_topic = "RegneCentralen RC3600/RC7000",
         ddhf_topic_link = 'https://datamuseum.dk/wiki/RC/RC7000',

--- a/ddhf_rc700.py
+++ b/ddhf_rc700.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Rc700(ddhf.DDHF_Excavation):
+class DDHF_Rc700(ddhf.DDHF_Excavation):
 
     ''' All RC700 artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "-30003268", # Ligner CP/M men med COMAL-80 navne semantik
@@ -23,7 +21,7 @@ class Rc700(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Rc700,
+        DDHF_Rc700,
         html_subdir="rc700",
         ddhf_topic = 'RegneCentralen RC700 "Piccolo"',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/RC700_Piccolo'

--- a/ddhf_rc759.py
+++ b/ddhf_rc759.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Rc759(ddhf.DDHF_Excavation):
+class DDHF_Rc759(ddhf.DDHF_Excavation):
 
     ''' All RC759 artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "-30002875",
@@ -22,7 +20,7 @@ class Rc759(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Rc759,
+        DDHF_Rc759,
         html_subdir="rc759",
         ddhf_topic = 'RegneCentralen RC759 "Piccoline"',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/RC_Piccoline'

--- a/ddhf_rc850.py
+++ b/ddhf_rc850.py
@@ -4,16 +4,14 @@ Regnecentralen RC850 Artifacts from Datamuseum.dk's BitStore
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Rc850(ddhf.DDHF_Excavation):
+class DDHF_Rc850(ddhf.DDHF_Excavation):
 
     ''' All RC850 artifacts '''
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
+        super().__init__(Cpm, **kwargs)
 
         self.from_bitstore(
             "RC/RC850/CPM",
@@ -21,7 +19,7 @@ class Rc850(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Rc850,
+        DDHF_Rc850,
         html_subdir="rc850",
         ddhf_topic = 'RegneCentralen RC850',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/RC850'

--- a/ddhf_rc890.py
+++ b/ddhf_rc890.py
@@ -4,16 +4,14 @@
 '''
 
 from autoarchaeologist import ddhf
-from autoarchaeologist.ddhf import cpm_exc
+from autoarchaeologist.ddhf.cpm_excavator import Cpm
 
-class Rc890(ddhf.DDHF_Excavation):
+class DDHF_Rc890(ddhf.DDHF_Excavation):
 
     ''' All RC890 artifacts '''
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        cpm_exc.std_cpm_excavation(self)
 
         self.from_bitstore(
             "RC/RC890",
@@ -21,7 +19,7 @@ class Rc890(ddhf.DDHF_Excavation):
 
 if __name__ == "__main__":
     ddhf.main(
-        Rc890,
+        DDHF_Rc890,
         html_subdir="rc890",
         ddhf_topic = 'RegneCentralen RC890',
         ddhf_topic_link = 'https://datamuseum.dk/wiki/RC890'

--- a/ddhf_zilog_mcz.py
+++ b/ddhf_zilog_mcz.py
@@ -7,8 +7,9 @@ from autoarchaeologist import ddhf
 
 from autoarchaeologist.zilog import mcz
 from autoarchaeologist.generic import textfiles
+from autoarchaeologist.base import excavation
 
-class ZilogMCZ(ddhf.DDHF_Excavation):
+class ZilogMCZ(excavation.Excavation):
 
     ''' Zilog MCZ Floppy Disks '''
 
@@ -17,6 +18,10 @@ class ZilogMCZ(ddhf.DDHF_Excavation):
 
         self.add_examiner(mcz.MCZRIO)
         self.add_examiner(textfiles.TextFile)
+
+class DDHF_ZilogMCZ(ddhf.DDHF_Excavation):
+    def __init__(self, **kwargs):
+        super().__init__(ZilogMCZ, **kwargs)
 
         self.from_bitstore(
             "COMPANY/ZILOG",

--- a/run.py
+++ b/run.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import sys
+
+from autoarchaeologist.base.excavation import Excavation as ExcavationBase
+
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dir", default="/tmp/_autoarchaologist")
+    parser.add_argument('filename')
+
+    return parser.parse_args(args=argv)
+
+def process_arguments(args):
+    if args.dir == ".":
+        args.dir = os.path.join(os.getcwd(), "_autoarchaologist")
+    if args.filename is not None:
+        args.filename = os.path.abspath(args.filename)
+    else:
+        raise ValueError()
+
+    return args
+
+def perform_excavation(args, action_tuple):
+    match action_tuple:
+        case "excavator", Excavation:
+            assert issubclass(Excavation, ExcavationBase)
+            ctx = Excavation(html_dir=args.dir)
+        case action, _:
+            raise NotImplementedError(f"action: {action}")
+
+    ff = ctx.add_file_artifact(args.filename)
+
+    ctx.start_examination()
+
+    return ctx
+
+if __name__ == "__main__":
+    args = process_arguments(parse_arguments())
+
+    try:
+        os.mkdir(args.dir)
+    except FileExistsError:
+        pass
+
+    ctx = perform_excavation(args, ("none", None))
+    ctx.produce_html()
+    print("Now point your browser at", ctx.filename_for(ctx).link)

--- a/run.py
+++ b/run.py
@@ -2,11 +2,19 @@ import argparse
 import os
 import sys
 
+from autoarchaeologist import excavators
 from autoarchaeologist.base.excavation import Excavation as ExcavationBase
+
+def action_for_args(args):
+    if args.excavator is not None:
+        return ("excavator", excavators.excavator_by_name(args.excavator))
+    else:
+        raise argparse.ArgumentError(None, "no valid excavation was requsted")
 
 def parse_arguments(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--dir", default="/tmp/_autoarchaologist")
+    parser.add_argument('--excavator', choices=excavators.__all__)
     parser.add_argument('filename')
 
     return parser.parse_args(args=argv)
@@ -43,6 +51,6 @@ if __name__ == "__main__":
     except FileExistsError:
         pass
 
-    ctx = perform_excavation(args, ("none", None))
+    ctx = perform_excavation(args, action_for_args(args))
     ctx.produce_html()
     print("Now point your browser at", ctx.filename_for(ctx).link)

--- a/run_example.py
+++ b/run_example.py
@@ -1,5 +1,7 @@
 
+import argparse
 import os
+import sys
 
 import autoarchaeologist
 
@@ -8,10 +10,24 @@ from autoarchaeologist.generic.samesame import SameSame
 from autoarchaeologist.data_general.absbin import AbsBin
 from autoarchaeologist.data_general.papertapechecksum import DGC_PaperTapeCheckSum
 
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dir", default="/tmp/_autoarchaologist")
+
+    args = parser.parse_args(args=argv)
+    if args.dir == ".":
+        args.dir = os.path.join(os.getcwd(), "_autoarchaologist")
+    return args
 
 if __name__ == "__main__":
+    args = parse_arguments()
 
-    ctx = autoarchaeologist.Excavation()
+    try:
+        os.mkdir(args.dir)
+    except FileExistsError:
+        pass
+
+    ctx = autoarchaeologist.Excavation(html_dir=args.dir)
 
     ctx.add_examiner(BigDigits)
     ctx.add_examiner(AbsBin)
@@ -22,11 +38,6 @@ if __name__ == "__main__":
 
     ctx.start_examination()
 
-    try:
-        os.mkdir("/tmp/_autoarchaologist")
-    except FileExistsError:
-        pass
-
-    ctx.produce_html(html_dir="/tmp/_autoarchaologist")
+    ctx.produce_html()
 
     print("Now point your browser at", ctx.filename_for(ctx).link)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+sys.path.append(ROOT_DIR)

--- a/tests/autoarchaologist/test_excavators.py
+++ b/tests/autoarchaologist/test_excavators.py
@@ -1,0 +1,36 @@
+import unittest
+
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "../.."))
+sys.path.append(ROOT_DIR)
+
+from autoarchaeologist import excavators
+from autoarchaeologist.base import excavation
+
+class ExcavationsSmoke(unittest.TestCase):
+    """
+    Smoke tests ensuring defined excavations are exported correctly.
+    """
+
+    @staticmethod
+    def define_excavation_test(test_case, excavator_name):
+        def _excavation_test(self):
+            Excavation = None
+            try:
+                Excavation = excavators.excavator_by_name(excavator_name)
+            except:
+                self.fail(f'unable to retriveve excavator "{excavator_name}"')
+            self.assertTrue(issubclass(Excavation, excavation.Excavation))
+
+        _excavation_test.__name__ = "test_%s" % excavator_name
+        _excavation_test.__doc__ = f"{excavator_name} smoke test"
+        setattr(test_case, _excavation_test.__name__, _excavation_test)
+
+for excavator_name in excavators.__all__:
+    ExcavationsSmoke.define_excavation_test(ExcavationsSmoke, excavator_name)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -1,0 +1,103 @@
+import importlib
+import os
+import shutil
+import sys
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.normpath(os.path.join(TESTS_DIR, ".."))
+
+# run_example is technically outside the package so force its import
+sys.path.append(ROOT_DIR)
+from run_example import process_example
+from autoarchaeologist.base.artifact import ArtifactBase, ArtifactStream
+sys.path.remove(ROOT_DIR)
+
+SCRATCH_DIR = os.path.join(TESTS_DIR, "_scratch")
+
+def scratch_path(path):
+    return os.path.join(SCRATCH_DIR, path)
+
+class RunExampleBasicHtml(unittest.TestCase):
+    """
+    Ensure run_example produces expected HTML files for the example input.
+    """
+
+    DIR_TREE = None
+
+    @classmethod
+    def setUpClass(cls):
+        shutil.rmtree(SCRATCH_DIR)
+        os.makedirs(SCRATCH_DIR, exist_ok=True)
+        ctx = process_example(html_dir=SCRATCH_DIR)
+        ctx.produce_html()
+        cls.DIR_TREE = list(os.walk(SCRATCH_DIR))
+
+    def toplevel(self):
+        return self.__class__.DIR_TREE[0]
+
+    def toplevel_dirnames(self):
+        _, dirs, __ = self.toplevel()
+        dirs.sort()
+        return dirs
+
+    def toplevel_filenames(self):
+        _, __, filenames = self.toplevel()
+        return filenames
+
+    def test_produces_top_level_index(self):
+        toplevel_filenames = self.toplevel_filenames()
+        self.assertTrue("index.html" in toplevel_filenames)
+        self.assertTrue("index.css" in toplevel_filenames)
+
+    def test_produces_digest_directories(self):
+        toplevel_dirnames = self.toplevel_dirnames()
+        self.assertEqual(toplevel_dirnames, ['08', '79', 'fa'])
+
+class RunExampleBasicArtifacts(unittest.TestCase):
+    """
+    Ensure run_example excavates the expected artifacts for the example input.
+    """
+
+    CTX = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.CTX = process_example(html_dir=SCRATCH_DIR)
+
+    def assertArtifactIsChild(self, artifact, parent):
+        assert issubclass(artifact.__class__, ArtifactBase)
+        self.assertEqual(list(artifact.parents), [parent])
+
+    def excavation(self):
+        return self.__class__.CTX
+
+    def test_excavated_three_total_artifacts(self):
+        arfifact_hash_keys = list(self.excavation().hashes.keys())
+        self.assertEqual(len(arfifact_hash_keys), 3)
+
+    def test_excavated_one_top_level_artifact(self):
+        excavatoin_child_count = len(self.excavation().children)
+        self.assertEqual(excavatoin_child_count, 1)
+
+    def test_produces_top_level_artifact(self):
+        excavation = self.excavation()
+        artifact = self.excavation().children[0]
+        self.assertIsInstance(artifact, ArtifactStream)
+        self.assertEqual(artifact.digest, '083a3d5e3098aec38ee5d9bc9f9880d3026e120ff8f058782d49ee3ccafd2a6c')
+
+    def test_produces_top_level_artifact_whose_parent_is_excavation(self):
+        artifact = self.excavation().children[0]
+        self.assertArtifactIsChild(artifact, self.excavation())
+
+    def test_produces_two_children_of_the_top_level(self):
+        artifact = self.excavation().children[0]
+        artifact_children = sorted(artifact.children, key=lambda a: a.digest)
+        self.assertEqual(len(artifact_children), 2)
+        self.assertTrue(artifact_children[0].digest.startswith('79'))
+        self.assertArtifactIsChild(artifact_children[0], artifact)
+        self.assertTrue(artifact_children[1].digest.startswith('fa'))
+        self.assertArtifactIsChild(artifact_children[1], artifact)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,33 @@
+import importlib
+import os
+import sys
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, ".."))
+sys.path.append(ROOT_DIR)
+
+DDHF_SCRIPTS = filter(lambda fname: os.path.basename(fname).startswith('ddhf_'), os.listdir())
+
+class DDHFScriptsTestCase(unittest.TestCase):
+    """
+    Smoke tests ensuring ddhf scripts can be loaded correctly.
+    """
+
+    @staticmethod
+    def define_script_test(test_case, script_name):
+        def _excavation_test(self):
+            try:
+                importlib.import_module(script_name)
+            except:
+                self.fail(script_name)
+        _excavation_test.__name__ = "test_%s" % script_name
+        _excavation_test.__doc__ = f"{script_name} script"
+        setattr(test_case, _excavation_test.__name__, _excavation_test)
+
+for script in DDHF_SCRIPTS:
+    script_name = script[:-3] # strip extension
+    DDHFScriptsTestCase.define_script_test(DDHFScriptsTestCase, script_name)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Provide a central excavators module which re-exports the various named configurations. Use this to implement a CLI recognizing a --excavator argument which will call an exacavtion of the supplied filename.

Rework run_example as a wrapper around this new unified CLI. Expand the README documenting both run_example and unified run entry points noting that in the absence of arguments a list of supported excavators is output.

While here add smoke tests for basic validation of exports and scripts.

> this PR is atop https://github.com/Datamuseum-DK/AutoArchaeologist/pull/4